### PR TITLE
Fixed Package Mismatch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         'argparse',
         'tqdm',
         "pytest",
-        'Surface-Distance-Based-Measures @ git+https://github.com/deepmind/surface-distance.git',
+        'surface-distance @ git+https://github.com/deepmind/surface-distance.git',
         'SimpleITK',
         "batchgenerators"
     ],


### PR DESCRIPTION
# Package Mismatch

## Description

```
ERROR: Could not find a version that satisfies the requirement surface-distance-based-measures (unavailable) (from kits23) (from versions: 0.1)

ERROR: No matching distribution found for surface-distance-based-measures (unavailable)
```

## Checklist

- [ ] Merged latest `master`
- [ ] Updated version number in `README.md`
- [ ] Added changes to `changelog.md`
- [ ] Updated version number in `setup.py`
- [ ] Version number in `kits23/_version.py` matches `setup.py`
- [ ] (only when updating dataset) Ran `annotation.import` to completion
